### PR TITLE
add_clip_modal

### DIFF
--- a/src/Page/Toppage.tsx
+++ b/src/Page/Toppage.tsx
@@ -5,14 +5,15 @@ import Sidebar from '../components/Sidebar';
 import { clips } from '../Data/DummyData';
 import '../css/Card.css';
 import '../css/Cliplist.css'
+import AddClipModal from '../components/AddClipModal';
 
 const Toppage: React.FC = () => {
   return (
     <div>
       <header>
         <Navbar
-          twitchClipperIconSrc="/public/vite.svg"
-          profileIconSrc="/public/vite.svg"
+          twitchClipperIconSrc="/vite.svg"
+          profileIconSrc="/vite.svg"
           isLogin={false}
         />
       </header>
@@ -20,6 +21,7 @@ const Toppage: React.FC = () => {
         <Sidebar />
         <Cliplist clips={clips}/>
       </div>
+      <AddClipModal />
     </div>
   );
 };

--- a/src/components/AddClipModal.tsx
+++ b/src/components/AddClipModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+const AddClipModal: React.FC = () => {
+  return (
+    <div className="modal fade" id="addClipModal" tabIndex={-1} aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div className="modal-dialog modal-dialog-centered">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title" id="exampleModalLabel">新規クリップ追加</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div className="modal-body">
+            <div className="input-group mb-3">
+              <span className="input-group-text" id="inputGroup-sizing-default">クリップURL</span>
+              <input type="text" className="form-control" placeholder='https://www.twitch.tv/user_name/clip/xxx-xxx' aria-label="Sizing example input" aria-describedby="inputGroup-sizing-default"/>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <button type="button" className="btn btn-primary">Submit</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AddClipModal

--- a/src/components/Cliplist.tsx
+++ b/src/components/Cliplist.tsx
@@ -28,7 +28,9 @@ const Cliplist: React.FC<CliplistProps> = ({ clips, onClick }) => {
               onClick={onClick}
             />
           ))}
-          <ClipCard title={"新規クリップ追加"} broadcaster_name={"tes"} thumbnail_url={addClipImage} onClick={onClick}/>
+          <div className="nav-link text-white" data-bs-toggle="modal" data-bs-target="#addClipModal">
+            <ClipCard title={"新規クリップ追加"} broadcaster_name={"tes"} thumbnail_url={addClipImage} onClick={onClick}/>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,21 +29,25 @@ const Sidebar: React.FC = () => {
   }, []);
 
   return (
+    <>
       <nav className="sidebar bg-dark">
         <ul className="nav flex-column">
             <li className="nav-item">
               <div className="nav-top text-white">プレイリスト一覧</div>
             </li>
             {playlists.map((playlist) => (
-              <li className="nav-item">
+              <li className="nav-item" key={playlist.id}>
                 <div className="nav-link text-white" onClick={() => {console.log('押すとプレイリストのidをCliplist.tsxにわたして、クリップリスト更新')}}>{playlist.playlist_name}</div>
               </li>
             ))}
-            <li className="nav-item">
-              <div className="nav-link text-white" onClick={() => {console.log('押すとプレイリスト作成のポップアップ表示')}}>+ 新規プレイリスト作成</div>
+            <li className='nav-item'>
+              <div className="nav-link text-white" data-bs-toggle="modal" data-bs-target="#exampleModal">
+              + 新規プレイリスト作成
+              </div>
             </li>
         </ul>
       </nav>
+    </>
   );
 };
 


### PR DESCRIPTION
## 🔨 変更内容

- 新規クリップ追加のカードをクリックするとクリップURLを入力するModalが出てくる

- あとついでにvite.svgのpath直した
- ついでにli要素にkey追加した(エラー対応

## 📸 スクリーンショット
![image](https://github.com/necocats/twitchclipper-frontend/assets/38724654/fd1bf146-4d73-46be-a655-db502d53fb7f)

## 📢 この PR に含まないこと

- 実際にプレイリストにクリップを追加する処理

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #19 

## 🤝 関連するイシュー

- #0
