### PR TITLE
get_clips_from_firebase

### DIFF
--- a/src/Page/Toppage.tsx
+++ b/src/Page/Toppage.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Cliplist from '../components/Cliplist';
 import Navbar from '../components/Navbar';
 import Sidebar from '../components/Sidebar';
-import { clips } from '../Data/DummyData';
 import '../css/Card.css';
 import '../css/Cliplist.css'
 import AddClipModal from '../components/AddClipModal';
 
 const Toppage: React.FC = () => {
+  const [currentPlaylistId, setCurrentPlaylistId] = useState<string>("");
+  const handlePlaylistIdChange = (playlistId: string) => {
+    setCurrentPlaylistId(playlistId);
+  }
   return (
     <div>
       <header>
@@ -18,8 +21,8 @@ const Toppage: React.FC = () => {
         />
       </header>
       <div className='d-flex'>
-        <Sidebar />
-        <Cliplist clips={clips}/>
+        <Sidebar handlePlaylistIdChange={handlePlaylistIdChange}/>
+        <Cliplist currentPlaylistId={currentPlaylistId}/>
       </div>
       <AddClipModal />
     </div>

--- a/src/components/Cliplist.tsx
+++ b/src/components/Cliplist.tsx
@@ -1,35 +1,64 @@
+import { FieldValue } from 'firebase/firestore';
 import '../css/Cliplist.css'
 import addClipImage from '../image/add_clip.png';
 import ClipCard from "./ClipCard";
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
 
-interface clip {
-  id: string
-  title: string,
-  broadcaster_name: string,
-  thumbnail_url: string,
+interface Clip {
+  clip_id: string;
+  user_id: string;
+  title: string;
+  broadcaster_name: string;
+  clip_url: string;
+  thumbnail_url: string;
+  created_at: FieldValue;
+  updated_at: FieldValue;
 }
 
 interface CliplistProps {
-  clips: clip[];
-  onClick?: () => void;
+  currentPlaylistId: string;
 }
 
-const Cliplist: React.FC<CliplistProps> = ({ clips, onClick }) => {
+// interface CliplistProps {
+//   clips: clip[];
+//   onClick?: () => void;
+// }
+
+const Cliplist: React.FC<CliplistProps> = ({ currentPlaylistId }) => {
+  const [clips, setClips] = useState<Clip[]>([]);
+  useEffect(() => {
+    const fetchPlaylists = async () => {
+      if(currentPlaylistId != ""){
+        try {
+          const playlistId = currentPlaylistId;
+          const response = await axios.get("http://localhost:8080/api/clips?playlistId=" + playlistId);
+          setClips(response.data);
+          
+        } catch (error) {
+          console.error('fetchPlaylists Error: ', error);
+        }
+      }
+    }
+    fetchPlaylists();
+  }, [currentPlaylistId]);
+
   return (
     <>
       <div className='content flex-grow-1'>
         <div className="d-flex flex-row flex-wrap clip-list">
-          {clips.map((clip) => (
-            <ClipCard  
-              key={clip.id}
-              title={clip.title} 
-              broadcaster_name={clip.broadcaster_name}
-              thumbnail_url={clip.thumbnail_url} 
-              onClick={onClick}
-            />
-          ))}
+          {
+            clips.map((clip) => (
+              <ClipCard
+                key={clip.clip_id}
+                title={clip.title} 
+                broadcaster_name={clip.broadcaster_name}
+                thumbnail_url={clip.thumbnail_url}
+              />
+            ))
+          }
           <div className="nav-link text-white" data-bs-toggle="modal" data-bs-target="#addClipModal">
-            <ClipCard title={"新規クリップ追加"} broadcaster_name={"tes"} thumbnail_url={addClipImage} onClick={onClick}/>
+            <ClipCard title={"新規クリップ追加"} broadcaster_name={"tes"} thumbnail_url={addClipImage}/>
           </div>
         </div>
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,11 @@ interface Playlist {
   updated_at: FieldValue;
 }
 
-const Sidebar: React.FC = () => {
+interface handleProps {
+  handlePlaylistIdChange: (playlistId: string) => void;
+}
+
+const Sidebar: React.FC<handleProps> = ({handlePlaylistIdChange}) => {
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
   useEffect(() => {
     const fetchPlaylists = async () => {
@@ -28,6 +32,10 @@ const Sidebar: React.FC = () => {
     fetchPlaylists();
   }, []);
 
+  const handleCurrentPlaylistIdChange = (playlistName: string) => {
+    handlePlaylistIdChange(playlistName);
+  }
+
   return (
     <>
       <nav className="sidebar bg-dark">
@@ -37,7 +45,7 @@ const Sidebar: React.FC = () => {
             </li>
             {playlists.map((playlist) => (
               <li className="nav-item" key={playlist.id}>
-                <div className="nav-link text-white" onClick={() => {console.log('押すとプレイリストのidをCliplist.tsxにわたして、クリップリスト更新')}}>{playlist.playlist_name}</div>
+                <div className="nav-link text-white" onClick={() => {handleCurrentPlaylistIdChange(playlist.id)}}>{playlist.playlist_name}</div>
               </li>
             ))}
             <li className='nav-item'>


### PR DESCRIPTION
## 🔨 変更内容

- firestoreから実際のクリップデータを引っ張ってきて表示
- 別のプレイリストを選択したらクリップも更新される

## 📸 スクリーンショット
![image](https://github.com/necocats/twitchclipper-frontend/assets/38724654/c56ca94a-2236-49a6-92b6-d7eb8189000b)

## 📢 この PR に含まないこと

- 初期状態に一番上のプレイリストの内容を表示してたらいいよねって思うけど、後回しにした

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #25 

## 🤝 関連するイシュー

- #0
