### PR TITLE
初期状態でクリップ作成を表示しない

### DIFF
--- a/src/components/Cliplist.tsx
+++ b/src/components/Cliplist.tsx
@@ -57,9 +57,16 @@ const Cliplist: React.FC<CliplistProps> = ({ currentPlaylistId }) => {
               />
             ))
           }
-          <div className="nav-link text-white" data-bs-toggle="modal" data-bs-target="#addClipModal">
-            <ClipCard title={"新規クリップ追加"} broadcaster_name={"tes"} thumbnail_url={addClipImage}/>
-          </div>
+          {
+            currentPlaylistId ? (
+              <div className="nav-link text-white" data-bs-toggle="modal" data-bs-target="#addClipModal">
+                <ClipCard title={"新規クリップ追加"} broadcaster_name={"tes"} thumbnail_url={addClipImage}/>
+              </div>
+            ) : (
+              <h2>左のプレイリストを選択してください</h2>
+            )
+          }
+
         </div>
       </div>
     </>


### PR DESCRIPTION
## 🔨 変更内容

- まじの応急処置
- プレイリストを選んでない状態で画像のようにする

## 📸 スクリーンショット
![image](https://github.com/necocats/twitchclipper-frontend/assets/38724654/85171892-131e-47cb-8fdb-4504b2b29a2b)

## 📢 この PR に含まないこと

- xxx

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #31 

## 🤝 関連するイシュー

- #0
