### PR TITLE
bug_fix_add_clip_modal

### DIFF
--- a/src/Page/Toppage.tsx
+++ b/src/Page/Toppage.tsx
@@ -78,7 +78,7 @@ const Toppage: React.FC = () => {
         <Cliplist userId={userId} currentPlaylistId={currentPlaylistId} currentPlaylistName={currentPlaylistName}/>
       </div>
       <AddPlaylistModal handlePlaylistChange={handlePlaylistChange}/>
-      <AddClipModal userId={userId} currentPlaylistId={currentPlaylistId}/>
+      <AddClipModal userId={userId} currentPlaylistId={currentPlaylistId} currentPlaylistName={currentPlaylistName} handlePlaylistChange={handlePlaylistChange}/>
     </div>
   );
 };

--- a/src/components/AddClipModal.tsx
+++ b/src/components/AddClipModal.tsx
@@ -4,9 +4,11 @@ import React, { useState } from 'react'
 interface AddClipModalProps {
   userId: string;
   currentPlaylistId: string;
+  currentPlaylistName: string;
+  handlePlaylistChange: (playlistId: string, playlistName: string) => void;
 }
 
-const AddClipModal: React.FC<AddClipModalProps> = ({ userId, currentPlaylistId }) => {
+const AddClipModal: React.FC<AddClipModalProps> = ({ userId, currentPlaylistId, currentPlaylistName, handlePlaylistChange }) => {
   const baseApiUrl = import.meta.env.VITE_BACKEND_BASE_API_URL;
   const [, setClipId] = useState('');
   const [clipUrl, setClipUrl] = useState('');
@@ -27,15 +29,20 @@ const AddClipModal: React.FC<AddClipModalProps> = ({ userId, currentPlaylistId }
         setClipId(response.data['clip_id']);
         if (currentPlaylistId) {
           try {
+            handlePlaylistChange("", currentPlaylistName);
             await axios.post(baseApiUrl + 'playlistclips', {
               playlistId: currentPlaylistId,
               clipId: response.data['clip_id'] 
             });
-            // window.location.reload();
-            const modalCloseButton = document.getElementById('btn-close');
+            // モーダルを閉じる
+            const modalCloseButton = document.getElementById('add-clip-btn-close');
             if(modalCloseButton){
               modalCloseButton.click();
             }
+            // クリップ一覧更新
+            handlePlaylistChange(currentPlaylistId, currentPlaylistName);
+            setClipUrl('');
+
           } catch (error) {
             console.error(error);
             handleErrorMessage('クリップの追加に失敗しました');
@@ -54,7 +61,7 @@ const AddClipModal: React.FC<AddClipModalProps> = ({ userId, currentPlaylistId }
         <div className="modal-content">
           <div className="modal-header">
             <h5 className="modal-title" id="exampleModalLabel">新規クリップ追加</h5>
-            <button type="button" id='btn-close' className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <button type="button" id='add-clip-btn-close' className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div className="modal-body">
             <div className="input-group mb-3">

--- a/src/components/AddPlaylistModal.tsx
+++ b/src/components/AddPlaylistModal.tsx
@@ -48,7 +48,7 @@ const AddPlaylistModal: React.FC<AddPlaylistModalProps> = ({handlePlaylistChange
         setTitle('');
         setDescription('');
         // モーダル閉じる
-        const modalCloseButton = document.getElementById('btn-close');
+        const modalCloseButton = document.getElementById('add-playlist-btn-close');
         if(modalCloseButton){
           modalCloseButton.click();
         }
@@ -70,7 +70,7 @@ const AddPlaylistModal: React.FC<AddPlaylistModalProps> = ({handlePlaylistChange
         <div className="modal-content">
           <div className="modal-header">
             <h5 className="modal-title" id="exampleModalLabel">新規プレイリスト作成</h5>
-            <button type="button" id='btn-close' className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <button type="button" id='add-playlist-btn-close' className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div className="modal-body">
             <div className="d-flex flex-column">
@@ -83,7 +83,7 @@ const AddPlaylistModal: React.FC<AddPlaylistModalProps> = ({handlePlaylistChange
                   aria-label="Sizing example input" 
                   aria-describedby="inputGroup-sizing-default"
                   value={title}
-                  onChange={(e) => setTitle(e.target.value)}
+                  onChange={(e) => {setTitle(e.target.value); e.target.value = "";}}
                   />
               </div>
               <div className="input-group mb-3">


### PR DESCRIPTION
## 🔨 変更内容

- クリップ追加の後モーダルが閉じない不具合の修正
- モーダルが閉じた後きちんとクリップ一覧も更新されるように
- モーダル内のクリップURLのvalueがずっと残っていたため、Submit後に消す処理を追加

## 📸 スクリーンショット

## 📢 この PR に含まないこと

- xxx

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #63 

## 🤝 関連するイシュー

- #0
